### PR TITLE
Replace spdx with spdx-expression-parse

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
-var spdx = require('spdx');
+var parse = require('spdx-expression-parse');
 
 function simplify(expression) {
   var licenses = [];
   var resultsToExplore = [];
   try {
-    resultsToExplore.push(spdx.parse(expression));
+    resultsToExplore.push(parse(expression));
   } catch (e) {
     // Eat parsing exceptions
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "mocha": "2.5.2"
   },
   "dependencies": {
-    "spdx": "0.5.1"
+    "spdx-expression-parse": "^1.0.2"
   }
 }


### PR DESCRIPTION
This tiny PR replaces with the package's dependency [spdx](https://www.npmjs.com/package/spdx) with its leaner, meaner successor, [spdx-expression-parse](https://www.npmjs.com/package/spdx-expression-parse).  For those in front-end work, this should bundle a little leaner.

The original package is more or less deprecated.  Any new work from me will be on [spdx-expression-parse](https://www.npmjs.com/package/spdx-expression-parse), which is also what npm v3 bundles for metadata validation.
